### PR TITLE
fixed cob pipe cannot craftable. and support new version of milk tag

### DIFF
--- a/src/main/resources/data/corn_delight/recipe/cob_pipe.json
+++ b/src/main/resources/data/corn_delight/recipe/cob_pipe.json
@@ -3,7 +3,7 @@
   "category": "misc",
   "ingredients": [
     {
-      "tag": "c:rods/wood"
+      "tag": "c:rods/wooden"
     },
     {
       "item": "corn_delight:corncob"

--- a/src/main/resources/data/corn_delight/recipe/cooking/corn_soup.json
+++ b/src/main/resources/data/corn_delight/recipe/cooking/corn_soup.json
@@ -25,7 +25,15 @@
       ]
     },
     {
-      "tag": "c:foods/milk"
+      "type": "neoforge:compound",
+      "children": [
+        {
+          "tag": "c:foods/milk"
+        },
+        {
+          "tag": "c:drinks/milk"
+        }
+      ]
     }
   ],
   "result": {

--- a/src/main/resources/data/corn_delight/recipe/cooking/creamed_corn.json
+++ b/src/main/resources/data/corn_delight/recipe/cooking/creamed_corn.json
@@ -8,7 +8,15 @@
       "tag": "c:seeds/corn"
     },
     {
-      "tag": "c:foods/milk"
+      "type": "neoforge:compound",
+      "children": [
+        {
+          "tag": "c:foods/milk"
+        },
+        {
+          "tag": "c:drinks/milk"
+        }
+      ]
     }
   ],
   "result": {

--- a/src/main/resources/data/corn_delight/recipe/cooking/creamy_corn_drink.json
+++ b/src/main/resources/data/corn_delight/recipe/cooking/creamy_corn_drink.json
@@ -5,7 +5,15 @@
       "tag": "c:crops/corn"
     },
     {
-      "tag": "c:foods/milk"
+      "type": "neoforge:compound",
+      "children": [
+        {
+          "tag": "c:foods/milk"
+        },
+        {
+          "tag": "c:drinks/milk"
+        }
+      ]
     },
     {
       "item": "minecraft:sugar"

--- a/src/main/resources/data/corn_delight/recipe/cooking/nachos_block.json
+++ b/src/main/resources/data/corn_delight/recipe/cooking/nachos_block.json
@@ -25,7 +25,15 @@
     ]
     },
     {
-      "tag": "c:foods/milk"
+      "type": "neoforge:compound",
+      "children": [
+        {
+          "tag": "c:foods/milk"
+        },
+        {
+          "tag": "c:drinks/milk"
+        }
+      ]
     },
     {
       "item": "farmersdelight:tomato_sauce"

--- a/src/main/resources/data/corn_delight/recipe/cornbread_batter.json
+++ b/src/main/resources/data/corn_delight/recipe/cornbread_batter.json
@@ -9,7 +9,15 @@
       "tag": "c:crops/corn"
     },
     {
-      "tag": "c:foods/milk"
+      "type": "neoforge:compound",
+      "children": [
+        {
+          "tag": "c:foods/milk"
+        },
+        {
+          "tag": "c:drinks/milk"
+        }
+      ]
     },
     {
       "tag": "c:eggs"


### PR DESCRIPTION
noted: new version of Milk Tag(c:drinks/milk) is using new neoforge version and next farmers delight